### PR TITLE
remove the `newRelic.` from the beginning of percentile attributes

### DIFF
--- a/src/main/java/com/codahale/metrics/newrelic/transformer/interfaces/SamplingTransformer.java
+++ b/src/main/java/com/codahale/metrics/newrelic/transformer/interfaces/SamplingTransformer.java
@@ -77,7 +77,7 @@ public class SamplingTransformer implements DropWizardComponentTransformer<Sampl
   }
 
   private Attributes buildAttributes(Attributes baseAttributes, Double percentile) {
-    return baseAttributes.put("newRelic.percentile", percentile * 100d);
+    return baseAttributes.put("percentile", percentile * 100d);
   }
 
   private double calculateSum(Snapshot snapshot) {

--- a/src/test/java/com/codahale/metrics/newrelic/transformer/interfaces/SamplingTransformerTest.java
+++ b/src/test/java/com/codahale/metrics/newrelic/transformer/interfaces/SamplingTransformerTest.java
@@ -158,6 +158,6 @@ class SamplingTransformerTest {
   }
 
   private Attributes percentileAttributes(double percentile) {
-    return new Attributes().put("newRelic.percentile", percentile);
+    return new Attributes().put("percentile", percentile);
   }
 }


### PR DESCRIPTION
resolves #34 