### PR TITLE
Addition of 'find and use data' from docs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# New Relic Dropwizard Reporter
+# New Relic Dropwizard reporter
 A [Dropwizard metrics](https://metrics.dropwizard.io/4.0.0/) reporter for sending dimensional metrics to New Relic using the New Relic Java Telemetry SDK.
 For the juicy details on how Dropwizard metrics are mapped to New Relic dimensional metrics,
 please visit [the exporter specs documentation repo](https://github.com/newrelic/exporter-specs/tree/master/dropwizard). 
@@ -33,7 +33,7 @@ MetricBatchSender sender = MetricBatchSender.builder().httpPoster(<your implemen
 Note: to use the sample code below, you will need the `telemetry-http-okhttp` library mentioned above. It provides
 implementations communicating via HTTP using the okhttp libraries, respectively.
 
-## Start The Reporter
+## Start the reporter
 
 Early in the lifecycle of your application, you will want to create and
 start a `NewRelicReporter`. 
@@ -58,7 +58,7 @@ NewRelicReporter reporter = NewRelicReporter.build(metricRegistry, metricBatchSe
 reporter.start(15, TimeUnit.SECONDS);
 ```
 
-## Dropwizard Integration
+## Dropwizard integration
 
 If you are using the actual Dropwizard REST framework, you can get a reference to the 
 `MetricRegistry` from the Dropwizard `Environment` in order to register your reporter.  
@@ -92,3 +92,12 @@ The project uses gradle 5 for building, and the gradle wrapper is provided.
 To compile, run the tests and build the jars:
 
 `$ ./gradlew build`
+
+### Find and use your data
+
+For tips on how to find and query your data, see [Find metric data](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data).
+
+For general querying information, see:
+- [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
+- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions)
+


### PR DESCRIPTION
This PR is to add a ‘how to find data’ section so that customers can find the data they send. I’ve included what I think are the applicable data types (metric data) but let me know if there are other data types reported by this exporter. If you think this exporter will change to send other types of data in future, keep in mind it will be important to update this with a link to that data type.

Also changed headers to preferred 'sentence case' style. 

I think 'reporter' should be decapitalized, but if you feel the official product name is 'New Relic Dropwizard Reporter' then keep that way if you want. 