### PR TITLE
Fix a version mismatch in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ please visit [the exporter specs documentation repo](https://github.com/newrelic
 `build.gradle:`
 ```
 compile("com.newrelic.telemetry:dropwizard-metrics-newrelic:0.5.0")
-compile("com.newrelic.telemetry:telemetry-http-okhttp:0.5.0")
+compile("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
 ```
 
 or if you're using kotlin build gradle...
@@ -18,7 +18,7 @@ or if you're using kotlin build gradle...
 `build.gradle.kts:`
 ```
 implementation("com.newrelic.telemetry:dropwizard-metrics-newrelic:0.5.0")
-implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.5.0")
+implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
 ```
 
 If you do not want to depend on okhttp, you can remove the dependency on `telemetry-http-okhttp`, 


### PR DESCRIPTION
The README suggests using the following dependencies:

```
compile("com.newrelic.telemetry:dropwizard-metrics-newrelic:0.5.0")
compile("com.newrelic.telemetry:telemetry-http-okhttp:0.5.0")
```

…but that won't work in practice because [`NewRelicReporterFactory` from `dropwizard-metrics-newrelic:0.5.0`](https://github.com/newrelic/dropwizard-metrics-newrelic/blob/v0.5.0/src/main/java/com/codahale/metrics/newrelic/NewRelicReporterFactory.java) tries to create an `OkHttpPoster` via a no-arg constructor: https://github.com/newrelic/dropwizard-metrics-newrelic/blob/b91cf6ca267830a6ea29a0d8c5721a3c3279bc40/src/main/java/com/codahale/metrics/newrelic/NewRelicReporterFactory.java#L35-L36

…and that constructor doesn't exist until `telemetry-http-okhttp:0.6.0`. The result is, in our case at least, a `NoSuchMethodError` at startup when trying to construct a `NewRelicReporter`.

This pull request updates the README to suggest using the latest version of `telemetry-http-okhttp`, which also aligns the README with what's in `build.gradle`.