### PR TITLE
bump dropwizard-metrics version to 2.0.28 to capture needed dependency version changes for vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ googleJavaFormat {
 dependencies {
     api("io.dropwizard.metrics:metrics-core:4.1.13")
     api("com.newrelic.telemetry:telemetry:0.8.0")
-    implementation("io.dropwizard:dropwizard-metrics:2.0.13")
+    implementation("io.dropwizard:dropwizard-metrics:2.0.28")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.8.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")


### PR DESCRIPTION
.