### PR TITLE
update newrelic telemetry libs to 0.15.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,9 +34,9 @@ googleJavaFormat {
 
 dependencies {
     api("io.dropwizard.metrics:metrics-core:4.2.9")
-    api("com.newrelic.telemetry:telemetry-core:0.13.2")
+    api("com.newrelic.telemetry:telemetry-core:0.15.0")
     implementation("io.dropwizard:dropwizard-metrics:2.1.0")
-    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.2")
+    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.15.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")


### PR DESCRIPTION
New Relic Telemetry Core and New Relic Telemetry OkHTTP is updated to version 0.15.0