### PR TITLE
Update Dropwizard Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 out/
 build
+*.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2022-05-09
+## [1.0.0] - 2023-05-09
 - Update to io.dropwizard:dropwizard-metrics 4.0.0.
-- Update to io.dropwizard.metrics:metrics-core 4.2.18.
 - Breaking change: this version no longer supports any Java version below Java 11. 
 
 ## [0.8.0] - 2022-09-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2022-09-21
+## [1.0.0] - 2022-05-09
 - Update to io.dropwizard:dropwizard-metrics 4.0.0.
 - Update to io.dropwizard.metrics:metrics-core 4.2.18.
 - Breaking change: this version no longer supports any Java version below Java 11. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2022-09-21
+- Update to io.dropwizard:dropwizard-metrics 4.0.0.
+- Update to io.dropwizard.metrics:metrics-core 4.2.18.
+- Breaking change: this version no longer supports any Java version below Java 11. 
+
 ## [0.8.0] - 2022-09-21
 - Update to telemetry SDK 0.15.0.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ public class MyApplication extends Application<MyConfig> {
 
 ### Dropwizard Metrics Reporter
 
-If you have a dropwizard project and have at least `dropwizard-core` 1.1.0, 
+If you have a dropwizard project and have at least `dropwizard-core` 2.1.6, 
 then you can perform the following steps to automatically report metrics to
 New Relic.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ please visit [the exporter specs documentation repo](https://github.com/newrelic
 Add required `build.gradle` dependencies to your project:
 
 ```
-implementation("com.newrelic.telemetry:dropwizard-metrics-newrelic:0.8.0")
+implementation("com.newrelic.telemetry:dropwizard-metrics-newrelic:1.0.0")
 implementation("com.newrelic.telemetry:telemetry-core:0.15.0")
 implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.15.0")
 ```
@@ -142,7 +142,7 @@ public class MyApplication extends Application<MyConfig> {
 
 ### Dropwizard Metrics Reporter
 
-If you have a dropwizard project and have at least `dropwizard-core` 0.7.X, 
+If you have a dropwizard project and have at least `dropwizard-core` 1.1.0, 
 then you can perform the following steps to automatically report metrics to
 New Relic.
 
@@ -169,7 +169,7 @@ in New Relic.
 [javadoc-url]: https://www.javadoc.io/doc/com.newrelic.telemetry/dropwizard-metrics-newrelic
 
 ### Building
-To compile, run the tests and build the jars:
+This project requires Java 11. To compile, run the tests and build the jars:
 
 `$ ./gradlew build`
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,9 @@ googleJavaFormat {
 }
 
 dependencies {
-    api("io.dropwizard.metrics:metrics-core:4.2.9")
+    api("io.dropwizard.metrics:metrics-core:4.2.18")
     api("com.newrelic.telemetry:telemetry-core:0.15.0")
-    implementation("io.dropwizard:dropwizard-metrics:2.1.1")
+    implementation("io.dropwizard:dropwizard-metrics:4.0.0")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.15.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
@@ -51,8 +51,8 @@ jar.apply {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
     withSourcesJar()
     withJavadocJar()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion = 0.9.0
+releaseVersion = 1.0.0
 
 # set this to true to enable using a local sonatype (for debugging publishing issues)
 # (start a local sonatype in docker with this command: $ docker run -d -p 8081:8081 --name nexus sonatype/nexus3)

--- a/src/main/java/com/codahale/metrics/newrelic/NewRelicReporterFactory.java
+++ b/src/main/java/com/codahale/metrics/newrelic/NewRelicReporterFactory.java
@@ -10,13 +10,13 @@ import com.newrelic.telemetry.MetricBatchSenderFactory;
 import com.newrelic.telemetry.OkHttpPoster;
 import com.newrelic.telemetry.SenderConfiguration;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
-import io.dropwizard.metrics.BaseReporterFactory;
+import io.dropwizard.metrics.common.BaseReporterFactory;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.Map;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 @JsonTypeName("newrelic")
 public class NewRelicReporterFactory extends BaseReporterFactory {


### PR DESCRIPTION
This PR:
- Updates to io.dropwizard:dropwizard-metrics 4.0.0.
- Updates to io.dropwizard.metrics:metrics-core 4.2.18.
- Breaking change: this version no longer supports any Java version below Java 11. 