### PR TITLE
Release dropwizard-metrics reporter v0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 out/
 build
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2022-05-09
+-Update to io.dropwizard:dropwizard-metrics 2.1.6.
+-Update to io.dropwizard.metrics:metrics-core 4.2.18.
+
 ## [0.8.0] - 2022-09-21
 - Update to telemetry SDK 0.15.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0] - 2022-05-09
+## [0.9.0] - 2023-05-09
 -Update to io.dropwizard:dropwizard-metrics 2.1.6.
 -Update to io.dropwizard.metrics:metrics-core 4.2.18.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ please visit [the exporter specs documentation repo](https://github.com/newrelic
 Add required `build.gradle` dependencies to your project:
 
 ```
-implementation("com.newrelic.telemetry:dropwizard-metrics-newrelic:0.8.0")
+implementation("com.newrelic.telemetry:dropwizard-metrics-newrelic:0.9.0")
 implementation("com.newrelic.telemetry:telemetry-core:0.15.0")
 implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.15.0")
 ```
@@ -142,7 +142,7 @@ public class MyApplication extends Application<MyConfig> {
 
 ### Dropwizard Metrics Reporter
 
-If you have a dropwizard project and have at least `dropwizard-core` 0.7.X, 
+If you have a dropwizard project and have at least `dropwizard-core` 1.1.X, 
 then you can perform the following steps to automatically report metrics to
 New Relic.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,9 @@ googleJavaFormat {
 }
 
 dependencies {
-    api("io.dropwizard.metrics:metrics-core:4.2.9")
+    api("io.dropwizard.metrics:metrics-core:4.2.18")
     api("com.newrelic.telemetry:telemetry-core:0.15.0")
-    implementation("io.dropwizard:dropwizard-metrics:2.1.1")
+    implementation("io.dropwizard:dropwizard-metrics:2.1.6")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.15.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,9 @@ googleJavaFormat {
 }
 
 dependencies {
-    api("io.dropwizard.metrics:metrics-core:4.2.18")
+    api("io.dropwizard.metrics:metrics-core:4.2.9")
     api("com.newrelic.telemetry:telemetry-core:0.15.0")
-    implementation("io.dropwizard:dropwizard-metrics:2.1.6")
+    implementation("io.dropwizard:dropwizard-metrics:2.1.1")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.15.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")


### PR DESCRIPTION
This PR is the last version of the dropwizard metrics reporter supporting Java 8. Changes from previous version:
- Update dropwizard-metrics to most recent version supporting Java 8 (version 2.1.6)
- Update dropwizard.metrics:metric-core to most recent version. 